### PR TITLE
Change border-box

### DIFF
--- a/src/styles/components/photoframe/photoframe.css
+++ b/src/styles/components/photoframe/photoframe.css
@@ -9,9 +9,6 @@
     border-radius:2px;
     background-color:white;
     max-width: 100%;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
 }
 a.photoframe img:hover, a .photoframe img:hover, .photoframe a img:hover, .linkblock:hover .photoframe img, .linkblock:hover .photoframe .photo {
     border:1px solid #777;

--- a/src/styles/core/grid/grids.css
+++ b/src/styles/core/grid/grids.css
@@ -1,7 +1,9 @@
+html {
+  box-sizing: border-box;
+}
+
 *, *:before, *:after {
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
+  box-sizing: inherit;
 }
 
 .line,.lastUnit{overflow:hidden; *overflow:visible;*zoom:1;}

--- a/src/styles/core/grid/grids.css
+++ b/src/styles/core/grid/grids.css
@@ -1,9 +1,9 @@
 html {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 *, *:before, *:after {
-  box-sizing: inherit;
+    box-sizing: inherit;
 }
 
 .line,.lastUnit{overflow:hidden; *overflow:visible;*zoom:1;}

--- a/src/styles/core/reset/html5-reset.css
+++ b/src/styles/core/reset/html5-reset.css
@@ -62,7 +62,6 @@ rt
 
 progress
 {
-    box-sizing: border-box;
     display: inline-block;
     height: 1em;
     width: 10em;
@@ -70,7 +69,6 @@ progress
 
 meter
 {
-    box-sizing: border-box;
     display: inline-block;
     height: 1em;
     width: 5em;


### PR DESCRIPTION
After reading css-tricks it looks like this is a better way to use boarder-box ->
https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/

I also removed box-sizing on progress and meter since it should be inherited.

The browser vendor prefixes should not be needed from (https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing)
Chrome 10, Safari 5.1 and Android 4.0 (-webkit)  
Firefox 29 (-moz)

Android browser is under 4% http://finn-no.github.io/nettlesermatrisen/ 
This is what Adobe could tell me about Android versions 
![Android versions](https://cloud.githubusercontent.com/assets/288977/6748914/40100172-ceeb-11e4-8165-c72cccf10a01.png)
Another source https://twitter.com/liksom/status/578467693554241536
