### PR TITLE
moved all Finn colored stuff into a separate package and added samples

### DIFF
--- a/src/samples/finnskin.html
+++ b/src/samples/finnskin.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+<head>
+<link rel="stylesheet" href="../styles/core/core.css">
+<link rel="stylesheet" href="../styles/components/components.css">
+<link rel="stylesheet" href="../styles/skins/finn/fonts/fonts.css">
+<link rel="stylesheet" href="../styles/skins/finn/form/form_elements.css">
+<link rel="stylesheet" href="../styles/skins/finn/template/template.css">
+<!--[if IE 9 ]>
+<link rel="stylesheet" type="text/css" media="screen,projection,handheld" href="../styules/ie9.css" />
+<![endif]-->
+<!--[if IE 8 ]>
+<link rel="stylesheet" type="text/css" media="screen,projection,handheld" href="../styules/ie8.css" />
+<![endif]-->
+<!--[if lte IE 8]>
+<link rel="stylesheet" type="text/css" media="screen,projection,handheld,print" href="../styules/ie.css" />
+<![endif]-->
+</head>
+<body>
+<div class="container">
+    <div class="page">
+        <h1>I am a cat</h1>
+        <h2>I am a cat</h2>
+        <h3>I am a cat</h3>
+        <h4>I am a cat</h4>
+        <p>I am a cat. I am a cat. I am a cat. I am a cat. I am a cat. I am a cat.
+        I am a cat. I am a cat. I am a cat. I am a cat. </p>
+
+        <div class="mod">
+            <div class="inner">
+                <div class="bd">
+                    <div class="media">
+                        <img class="img" src="">
+                        <p class="bd">This is a media block <a href="">test</a> inside a mod.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <form>
+            <fieldset>
+                <label for="email">Email</label>
+                <input type="email" name="email"><br>
+                <input  type="email" name="email"><br>
+                <input  type="file" name="email"><br>
+                <textarea></textarea><br>
+                <select>
+                <option> -- select -- </option>
+                </select>
+                <button>Save</button>
+                <button type="reset">Reset</button>
+            </fieldset>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/src/samples/noskins.html
+++ b/src/samples/noskins.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+<head>
+<link rel="stylesheet" href="../styles/core/core.css">
+<link rel="stylesheet" href="../styles/components/components.css">
+
+<!--[if IE 9 ]>
+<link rel="stylesheet" type="text/css" media="screen,projection,handheld" href="../styules/ie9.css" />
+<![endif]-->
+<!--[if IE 8 ]>
+<link rel="stylesheet" type="text/css" media="screen,projection,handheld" href="../styules/ie8.css" />
+<![endif]-->
+<!--[if lte IE 8]>
+<link rel="stylesheet" type="text/css" media="screen,projection,handheld,print" href="../styules/ie.css" />
+<![endif]-->
+</head>
+<body>
+<div class="container">
+    <div class="page">
+        <h1>I am a cat</h1>
+        <h2>I am a cat</h2>
+        <h3>I am a cat</h3>
+        <h4>I am a cat</h4>
+        <p>I am a cat. I am a cat. I am a cat. I am a cat. I am a cat. I am a cat.
+        I am a cat. I am a cat. I am a cat. I am a cat. </p>
+
+        <div class="mod">
+            <div class="inner">
+                <div class="bd">
+                    <div class="media">
+                        <img class="img" src="">
+                        <p class="bd">This is a media block <a href="">test</a> inside a mod.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <form>
+            <fieldset>
+                <label for="email">Email</label>
+                <input type="email" name="email"><br>
+                <input  type="email" name="email"><br>
+                <input  type="file" name="email"><br>
+                <textarea></textarea><br>
+                <select>
+                <option> -- select -- </option>
+                </select>
+                <button>Save</button>
+                <button type="reset">Reset</button>
+            </fieldset>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/src/styles/core/fonts/fonts.css
+++ b/src/styles/core/fonts/fonts.css
@@ -1,24 +1,7 @@
-@font-face {
-    font-family: finnmain;
-    src: local('HelveticaNeue-Light');
-    font-weight: normal;
-}
-
-@font-face {
-    font-family: finnmain;
-    src: local('HelveticaNeue');
-    font-weight: bold;
-}
-
-body {
-    font: 14px/1.5 finnmain, Arial, Helvetica, sans-serif;
-    color: #04253c;
-}
 
 html {font-size: 100%;}
 table{font-size:inherit;font:100%;}
 pre,code,kbd,samp,tt{font-family:monospace;line-height:100%;}
-code{color:#0B8C8F;}
 
 /* ====== Headings ====== */
 /* .h1-.h6 classes should be used to maintain the semantically appropriate heading levels - NOT for use on non-headings */
@@ -85,45 +68,6 @@ sup,sub{line-height:1em;}
 .uppercase { text-transform: uppercase; }
 
 
-/* default links */
-a, a:link { color:#07e; text-decoration:none; }
-a:visited { color: #07e; text-decoration:none; }
-a:hover, a:focus, a:active { text-decoration:underline; }
-a:focus{outline:none;}
-a.neutral { color: #666!important; }
-a > .neutral:hover,
-a:hover > .neutral { text-decoration: underline; }
-
-/* navigational links, visited on */
-a.userhistory:visited, .userhistory a:visited { color:#9ba8b1; }
-a.userhistory:visited:hover, .userhistory a:visited:hover {   }
-
-/* high contrast font color scheme */
-a.contrast:link,.contrast a:link { color:#eee; }
-a.contrast:visited,.contrast a:visited { color:#ddd; }
-a.contrast:focus,.contrast a:hover { color:#fff; }
-a.contrast:focus,.contrast a:focus,
-a.contrast:active,.contrast a:active { background:transparent; }
-
-/* navigational links, visited on */
-a.contrast.userhistory:link,.contrast.userhistory a:link { color:#eee; }
-a.contrast.userhistory:visited,.contrast.userhistory a:visited { color:#eee; }
-a.contrast.userhistory:focus,.contrast.userhistory a:hover { color:#fff; }
-
-/* dark links */
-a.dark-links,a.dark-links:link,.dark-links a,.dark-links a:link{color:#04253c;}
-a.dark-links:visited,.dark-links a:visited{color:#04253c;}
-a.dark-links:hover,.dark-links a:hover,a.dark-links:focus,.dark-links a:focus,a.dark-links:active,.dark-links a:active{ text-decoration: underline; }
-
-/* block the link styling */
-
-a.linkblock:hover, .linkblock a:hover, a.linkblock:active, .linkblock a:active, a.linkblock:focus, .linkblock a:focus, button.blank.linkblock:hover, button.blank.linkblock:active, button.blank.linkblock:focus { text-decoration: none; }
-
-/* toolbar links */
-a.toolbar,a.toolbar:link,.toolbar a,.toolbar a:link{color:#4f6676; text-decoration:none;}
-a.toolbar:visited,.toolbar a:visited{color:#4f6676; text-decoration:none;}
-a.toolbar:hover,.toolbar a:hover,a.toolbar:focus,.toolbar a:focus{color:#4f6676; text-decoration:none;}
-a.toolbar:active,.toolbar a:active{color:#4f6676; text-decoration:none;}
 
 /* tagwords */
 a.tagword {
@@ -138,7 +82,7 @@ a.tagword:before{
 a.tagword.editable:before, .editable a.tagword:before{
     content:'';
     color:#9BA8B1;
-}      
+}
 a.tagword.editable:after, .editable a.tagword:after{
     content:'';
     margin-left: 5px;
@@ -146,7 +90,7 @@ a.tagword.editable:after, .editable a.tagword:after{
     width:8px;
     display:inline-block;
     background: url(data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB3aWR0aD0iOHB4IiBoZWlnaHQ9IjhweCIgdmlld0JveD0iMCAwIDggOCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgOCA4OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxnPgoJPHBhdGggZmlsbD0iIzlCQThCMSIgZD0iTTUuNiw0TDgsNi40TDYuNCw4TDQsNS42TDEuNiw4TDAsNi40TDIuNCw0TDAsMS42TDEuNiwwTDQsMi40TDYuNCwwTDgsMS42TDUuNiw0eiIvPgo8L2c+Cjwvc3ZnPg==);
-}   
+}
 a.tagword.editable, .editable a.tagword{
     background-color: #4f6676;
     border-radius: 2px;

--- a/src/styles/core/form/form_elements.css
+++ b/src/styles/core/form/form_elements.css
@@ -6,7 +6,6 @@ a.icon,
 a.button{
   font: inherit;
   font-size: 16px; /* This avoids zooming on iOS */
-  color:#04253C;
 }
 
 input:not([type]),
@@ -25,25 +24,9 @@ textarea{
   padding: 10px 5px;
   height:auto;
   border:1px solid;
-  background-color:#fff;
-  border-color:#9ba8b1;
   border-radius:2px;
   outline: none;
   line-height: 1.25em;
-}
-
-input:not([type]):hover,
-input[type="text"]:hover,
-input[type="password"]:hover,
-input[type="url"]:hover,
-input[type="tel"]:hover,
-input[type="search"]:hover,
-input[type="email"]:hover,
-input[type="date"]:hover,
-input[type="number"]:hover,
-select:hover,
-textarea:hover{
-  border-color:#7d868c;
 }
 
 select{
@@ -51,20 +34,6 @@ select{
   padding-top: 4px;
 }
 
-input:not([type]):disabled,
-input[type="text"]:disabled,
-input[type="password"]:disabled,
-input[type="url"]:disabled,
-input[type="tel"]:disabled,
-input[type="search"]:disabled,
-input[type="email"]:disabled,
-input[type="date"]:disabled,
-input[type="number"]:disabled,
-select:disabled,
-textarea:disabled{
-    color:#9ba8b1;
-    background-color:#edf0f1;
-}
 input[type=checkbox],
 input[type=radio] {
     cursor: pointer;
@@ -79,21 +48,6 @@ input[type=file] {
     border: initial;
     line-height: initial;
     box-shadow: none;
-}
-/* eksperimentel søkeicon i søkefelt :sn */
-input[type="search"]{
-    background: #fff url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNSIgaGVpZ2h0PSIxNSIgdmlld0JveD0iMTkuNSAxMTkuNSA2MiA2MiIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAxOS41IDExOS41IDYyIDYyIj48cGF0aCBkPSJNNjUuNzk5IDE0Ni4wODNjMC0xMC44MjMtOC43NzctMTkuNjAxLTE5LjYxNS0xOS42MDEtMTAuODMgMC0xOS42MTQgOC43NzctMTkuNjE0IDE5LjYwMSAwIDEwLjgzOSA4Ljc4NCAxOS42MTYgMTkuNjE0IDE5LjYxNiAxMC44MzcgMCAxOS42MTUtOC43NzcgMTkuNjE1LTE5LjYxNnoiIGZpbGw9Im5vbmUiLz48cGF0aCBmaWxsPSIjOWJhOGIxIiBkPSJNODAuOTgyIDE3NS44MThsLTEzLjkyLTEzLjkyNGMzLjMzNi00LjM5MyA1LjMxNi05Ljg2NyA1LjMxNi0xNS44MTIgMC0xNC40NTctMTEuNzI1LTI2LjE3Ny0yNi4xOTUtMjYuMTc3LTE0LjQ1NyAwLTI2LjE4NCAxMS43Mi0yNi4xODQgMjYuMTc3IDAgMTQuNDcyIDExLjcyNyAyNi4xOTYgMjYuMTg0IDI2LjE5NiA1LjkyOSAwIDExLjQwOC0xLjk4MyAxNS43OTQtNS4zMDdsMTMuOTI0IDEzLjkyMiA1LjA4MS01LjA3NXptLTU0LjQxMi0yOS43MzVjMC0xMC44MjMgOC43ODQtMTkuNjAxIDE5LjYxNC0xOS42MDEgMTAuODM1IDAgMTkuNjE1IDguNzc3IDE5LjYxNSAxOS42MDEgMCAxMC44MzktOC43NzcgMTkuNjE2LTE5LjYxNSAxOS42MTYtMTAuODMgMC0xOS42MTQtOC43NzctMTkuNjE0LTE5LjYxNnoiLz48L3N2Zz4=)
-                10px center no-repeat;
-    text-indent: 20px;
-    -webkit-transition: border linear 0.1s, text-indent 0.1s, box-shadow 0.1s, background-position 0.1s;
-    transition: border linear 0.1s, text-indent 0.1s, box-shadow 0.1s, background-position 0.1s;
-    -webkit-appearance: none;
-    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-input[type="search"]:focus {
-    background-position: -20px center;
-    text-indent: 0;
 }
 
 select[multiple] {
@@ -122,21 +76,6 @@ textarea {
     box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
-input:not([type]):focus,
-input[type="text"]:focus,
-input[type="password"]:focus,
-input[type="url"]:focus,
-input[type="tel"]:focus,
-input[type="search"]:focus,
-input[type="email"]:focus,
-input[type="date"]:focus,
-input[type="number"]:focus,
-textarea:focus,
-select:focus {
-    outline: 0;
-    border-color: #52A8EC;
-    box-shadow: inset 1px 1px 6px rgba(79, 102, 118, 0.25);
-}
 
 /* Input status */
 /* .invalid  */
@@ -171,19 +110,12 @@ a.button{
   border:1px solid;
   padding: 10px 12px;
   margin: 0;
-  color:#0077ee;
-  border-color: #0077ee;
   border-radius: 2px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   height: auto;
   outline: none;
-  background: #fdfeff;
-  background-image: -moz-linear-gradient(top, #fdfeff, #f4fbff);
-  background-image: -webkit-linear-gradient(top, #fdfeff, #f4fbff);
-  background-image: -o-linear-gradient(top, #fdfeff, #f4fbff);
-  background-image: linear-gradient(top, #fdfeff, #f4fbff);
   line-height: 1.25em;
 }
 input[type=button]::-moz-focus-inner,
@@ -198,7 +130,6 @@ input[type=reset]:hover,
 button:hover,
 a.icon:hover,
 a.button:hover{
-    background: #f2faff;
     text-decoration: none;
 }
 input[type=button]:active,
@@ -207,101 +138,9 @@ input[type=reset]:active,
 button:active,
 a.icon:active,
 a.button:active{
-  background: #e5f5ff;
   text-decoration: none;
 }
-input.order,
-button.order,
-a.icon.order,
-a.button.order{
-    border:1px solid #e68007;
-    background: #fb8b08;
-    background-image: -moz-linear-gradient(top, #fb8b08, #e68007);
-    background-image: -webkit-linear-gradient(top, #fb8b08, #e68007);
-    background-image: -o-linear-gradient(top, #fb8b08, #e68007);
-    background-image: linear-gradient(top, #fb8b08, #e68007);
-    color:#fff;
-}
-input:not([disabled]).order:hover,
-button:not([disabled]).order:hover,
-a.icon.order:hover,
-a.button.order:not(.disabled):hover {
-    background:#fe8d08;
-}
-input:not([disabled]).order:active,
-button:not([disabled]).order:active,
-a.icon.order:active,
-a.button.order:not(.disabled):active {
-    background:#e78007;
-}
-input.primary,
-button.primary,
-a.icon.primary,
-a.button.primary{
-    border:1px solid #007cf0;
-    background: #0095fd;
-    background-image: -moz-linear-gradient(top, #0095fd, #007cf0);
-    background-image: -webkit-linear-gradient(top, #0095fd, #007cf0);
-    background-image: -o-linear-gradient(top, #0095fd, #007cf0);
-    background-image: linear-gradient(top, #0095fd, #007cf0);
-    color:#fff;
- }
-input:not([disabled]).primary:hover,
-button:not([disabled]).primary:hover,
-a.icon.primary:hover,
-a.button.primary:not(.disabled):hover {
-    background: #0099ff;
-    box-shadow: 0 0 6px rgba(07, 37, 60, 0.4);
-    background-image: none;
-}
-input:not([disabled]).primary:active,
-button:not([disabled]).primary:active,
-a.icon.primary:active,
-a.button.primary:not(.disabled):active {
-    background: #0077ee;
-}
 
-input:disabled[type=button],
-input:disabled[type=submit],
-input:disabled[type=reset],
-button:disabled,
-a.button.disabled {
-    border:1px solid #e2e6e9;
-    background: #e2e6e9;
-    color:#9ba8b1;
-    background-image:none;
-}
-button:not([disabled]):focus,
-a.icon:focus,
-a.button:not(.disabled):focus{
-    box-shadow: 0 0 6px rgba(07, 37, 60, 0.4);
-    background-image: none;
-    text-decoration: none;
-}
-
-.inprogress {
-    background-size: 30px 30px!important;
-    background-image: -webkit-linear-gradient(135deg, rgba(0, 0, 0, .05) 25%, transparent 25%,
-    transparent 50%, rgba(0, 0, 0, .05) 50%, rgba(0, 0, 0, .05) 75%,
-    transparent 75%, transparent)!important;
-    background-image: -moz-linear-gradient(135deg, rgba(0, 0, 0, .05) 25%, transparent 25%,
-    transparent 50%, rgba(0, 0, 0, .05) 50%, rgba(0, 0, 0, .05) 75%,
-    transparent 75%, transparent)!important;
-    background-image: -o-linear-gradient(135deg, rgba(0, 0, 0, .05) 25%, transparent 25%,
-    transparent 50%, rgba(0, 0, 0, .05) 50%, rgba(0, 0, 0, .05) 75%,
-    transparent 75%, transparent)!important;
-    background-image: linear-gradient(135deg, rgba(0, 0, 0, .05) 25%, transparent 25%,
-    transparent 50%, rgba(0, 0, 0, .05) 50%, rgba(0, 0, 0, .05) 75%,
-    transparent 75%, transparent)!important;
-
-    -webkit-animation: animate-inprogress 3s linear infinite;
-    -o-animation: animate-inprogress 3s linear infinite;
-    animation: animate-inprogress 3s linear infinite;
-}
-
-@-webkit-keyframes animate-inprogress { 0% {background-position: 0 0;} 100% {background-position: 60px 0;} }
-@-o-keyframes animate-inprogress { 0% {background-position: 0 0;} 100% {background-position: 60px 0;} }
-@keyframes animate-inprogress { 0% {background-position: 0 0;} 100% {background-position: 60px 0;} }
 
 /* Input responsive */
 @media screen and (min-width:768px) {

--- a/src/styles/core/template/template.css
+++ b/src/styles/core/template/template.css
@@ -1,9 +1,6 @@
 /* **************** TEMPLATE ***************** */
 /* ====== Page Head, Body, and Foot ====== */
 .main{display:table-cell;*display:block;width:auto;}
-body, html {
-    background-color:#e9eff5;
-}
 .body,.main{*zoom:1;}
 .body:after,.main:after{clear:both;display:block;visibility:hidden;overflow:hidden;height:0 !important;line-height:0;font-size:xx-large;content:" x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x ";}
 .page{width:auto;_text-align:left;margin-left:2px;}
@@ -12,9 +9,9 @@ body, html {
 .topbar.fixed.defaultopen + .container,
 .topbar-level2.fixed:not(.hidden) + .container { margin-top: 110px; }
 .container.fullsize { max-width: 100%; }
- 
+
 /* wraps other template elems to set width */ /* text-align IE5.5 */
-/*? 
+/*?
 .liquid, .liquid .page {max-width: none!important;} */
 /* ====== Columns ====== */
 

--- a/src/styles/finn.css
+++ b/src/styles/finn.css
@@ -1,43 +1,47 @@
+@import url("skins/finn/fonts/fonts.css");
+@import url("skins/finn/form/form_elements.css");
+@import url("skins/finn/template/tempalte.css");
+
 /*
-	Skal kun inneholde finnspesifikt stuff, ikke skap avhengigheter slik at andre må inkludere denne. 
+	Skal kun inneholde finnspesifikt stuff, ikke skap avhengigheter slik at andre må inkludere denne.
 
 */
 
 /* forbrukertrygghet */
-.warranty .hd { 
-	background-image: url("/img/happylock.png"); 
-	background-repeat: no-repeat; 
-	background-position: 20px 5px; 
-	padding-left: 25px; 
+.warranty .hd {
+	background-image: url("/img/happylock.png");
+	background-repeat: no-repeat;
+	background-position: 20px 5px;
+	padding-left: 25px;
 }
-.warranty ol li { 
-	list-style-type: decimal; margin: 0 0 5px 20px; 
+.warranty ol li {
+	list-style-type: decimal; margin: 0 0 5px 20px;
 }
-.warranty-inline img { 
-	padding: 7px 10px; border-radius: 3px; 
+.warranty-inline img {
+	padding: 7px 10px; border-radius: 3px;
 }
 
 /* annonser forkledd som innhold */
-.advertisement { 
-	font-size: 12px; color: #333; 
+.advertisement {
+	font-size: 12px; color: #333;
 }
-.advertisement .smalltext { 
-	font-size: 9px; font-weight: normal; 
+.advertisement .smalltext {
+	font-size: 9px; font-weight: normal;
 }
 
 /* annonseinnlegging */
-.newobject .inner { 
-	background-image: url("/img/icon_register.png"); 
-	background-repeat: no-repeat; 
-	background-position: 20px 10px; 
-	height: 70px; 
-	line-height: 50px; 
-	text-indent: 70px; 
+.newobject .inner {
+	background-image: url("/img/icon_register.png");
+	background-repeat: no-repeat;
+	background-position: 20px 10px;
+	height: 70px;
+	line-height: 50px;
+	text-indent: 70px;
 }
 
 /* markedsforside */
-.frontpage-search .searchlinks .mrm:last-child { 
-	margin-right: 0!important; 
+.frontpage-search .searchlinks .mrm:last-child {
+	margin-right: 0!important;
 }
 
 /* Advanced search */
@@ -122,9 +126,9 @@
 }
 
 /* Flere annonser fra ... */
-.crosspromotion img { 
-	max-width: 100%; 
-	max-height: 60px; 
+.crosspromotion img {
+	max-width: 100%;
+	max-height: 60px;
 }
 
 /* Bli brediftskunde  */
@@ -137,15 +141,15 @@
 }
 
 /* Tredjepartsinnhold p� objektsiden */
-.separated-content { 
-	border:1px solid #eee; 
-	border-radius:2px; 
-	padding-right:10px; 
-	padding-top:5px; 
-	box-shadow:inset 0 3px 10px #efefef; 
+.separated-content {
+	border:1px solid #eee;
+	border-radius:2px;
+	padding-right:10px;
+	padding-top:5px;
+	box-shadow:inset 0 3px 10px #efefef;
 }
-.separated-content:hover { 
-	border:1px solid #ccc; 
+.separated-content:hover {
+	border:1px solid #ccc;
 }
 /* filter */
 .multicollist li{
@@ -180,35 +184,35 @@
 }
 
 /* Annonsegalleri */
-.ad-gallery.horizontal .logoframe { 
-	height: 105px; 
-	display: table-cell; 
+.ad-gallery.horizontal .logoframe {
+	height: 105px;
+	display: table-cell;
 	vertical-align: middle; }
-.ad-gallery.horizontal .unit { 
-	border-right: 1px solid #edf0f1; 
-	min-height: 165px; 
+.ad-gallery.horizontal .unit {
+	border-right: 1px solid #edf0f1;
+	min-height: 165px;
 }
-.ad-gallery.horizontal .lastUnit { 
-	border-right: none; 
+.ad-gallery.horizontal .lastUnit {
+	border-right: none;
 }
-.ad-gallery img { 
-	max-height: 100px; 
-	max-width: 135px; 
+.ad-gallery img {
+	max-height: 100px;
+	max-width: 135px;
 }
-.ad-gallery.vertical img { 
-	max-height: 150px; 
+.ad-gallery.vertical img {
+	max-height: 150px;
 }
-.ad-gallery .pseudoCrop { 
-	max-width: 100%!important; 
+.ad-gallery .pseudoCrop {
+	max-width: 100%!important;
 }
-.ad-gallery.horizontal .logoframe { 
-	*text-align: left; 
+.ad-gallery.horizontal .logoframe {
+	*text-align: left;
 	} /* IE7 */
-.ad-gallery.horizontal .mam { 
-	*margin: 5px!important; 
+.ad-gallery.horizontal .mam {
+	*margin: 5px!important;
 	} /* IE7 */
-.ad-gallery.horizontal .unit { 
-	*height: 165px; 
+.ad-gallery.horizontal .unit {
+	*height: 165px;
 	} /* IE7 */
 
 /* Jquery UI datepicker */
@@ -226,35 +230,35 @@
     cursor: pointer;
 }
 /* Object beskrivelsestekster */
-.object-description table { 
-	margin-left: 20px; 
+.object-description table {
+	margin-left: 20px;
 }
-.object-description strong em, .article strong em { 
-	font-weight: bold; 
+.object-description strong em, .article strong em {
+	font-weight: bold;
 }
-.object-description em strong, .article em strong { 
-	font-style: italic; 
+.object-description em strong, .article em strong {
+	font-style: italic;
 }
-.object .colspan2 hr:last-child { 
-	display: none; 
+.object .colspan2 hr:last-child {
+	display: none;
 } /* Deprecated? */
 
 /* Partnerinfo */
-.partnerinfo li { 
-	list-style: none; 
+.partnerinfo li {
+	list-style: none;
 }
-.partnerinfo li ul li { 
-	list-style: disc outside; 
+.partnerinfo li ul li {
+	list-style: disc outside;
 }
 
 /* Checked headline */
-.checked-headline:before { 
-	content: url("/img/check.png"); 
-	margin-left: -30px; 
-	margin-right: 11px; 
-	display: block; 
-	float: left; 
-	margin-top: 2px; 
+.checked-headline:before {
+	content: url("/img/check.png");
+	margin-left: -30px;
+	margin-right: 11px;
+	display: block;
+	float: left;
+	margin-top: 2px;
 }
 
 /* Oppdrag intern reklame */

--- a/src/styles/skins/finn/fonts/fonts.css
+++ b/src/styles/skins/finn/fonts/fonts.css
@@ -1,0 +1,39 @@
+/* default links */
+a, a:link { color:#07e; text-decoration:none; }
+a:visited { color: #07e; text-decoration:none; }
+a:hover, a:focus, a:active { text-decoration:underline; }
+a:focus{outline:none;}
+a.neutral { color: #666!important; }
+a > .neutral:hover,
+a:hover > .neutral { text-decoration: underline; }
+
+/* navigational links, visited on */
+a.userhistory:visited, .userhistory a:visited { color:#9ba8b1; }
+a.userhistory:visited:hover, .userhistory a:visited:hover {   }
+
+/* high contrast font color scheme */
+a.contrast:link,.contrast a:link { color:#eee; }
+a.contrast:visited,.contrast a:visited { color:#ddd; }
+a.contrast:focus,.contrast a:hover { color:#fff; }
+a.contrast:focus,.contrast a:focus,
+a.contrast:active,.contrast a:active { background:transparent; }
+
+/* navigational links, visited on */
+a.contrast.userhistory:link,.contrast.userhistory a:link { color:#eee; }
+a.contrast.userhistory:visited,.contrast.userhistory a:visited { color:#eee; }
+a.contrast.userhistory:focus,.contrast.userhistory a:hover { color:#fff; }
+
+/* dark links */
+a.dark-links,a.dark-links:link,.dark-links a,.dark-links a:link{color:#04253c;}
+a.dark-links:visited,.dark-links a:visited{color:#04253c;}
+a.dark-links:hover,.dark-links a:hover,a.dark-links:focus,.dark-links a:focus,a.dark-links:active,.dark-links a:active{ text-decoration: underline; }
+
+/* block the link styling */
+
+a.linkblock:hover, .linkblock a:hover, a.linkblock:active, .linkblock a:active, a.linkblock:focus, .linkblock a:focus, button.blank.linkblock:hover, button.blank.linkblock:active, button.blank.linkblock:focus { text-decoration: none; }
+
+/* toolbar links */
+a.toolbar,a.toolbar:link,.toolbar a,.toolbar a:link{color:#4f6676; text-decoration:none;}
+a.toolbar:visited,.toolbar a:visited{color:#4f6676; text-decoration:none;}
+a.toolbar:hover,.toolbar a:hover,a.toolbar:focus,.toolbar a:focus{color:#4f6676; text-decoration:none;}
+a.toolbar:active,.toolbar a:active{color:#4f6676; text-decoration:none;}

--- a/src/styles/skins/finn/form/form_elements.css
+++ b/src/styles/skins/finn/form/form_elements.css
@@ -1,0 +1,157 @@
+input,
+select,
+textarea,
+button,
+a.icon,
+a.button{
+  font: inherit;
+  font-size: 16px; /* This avoids zooming on iOS */
+  color:#04253C;
+}
+
+input:not([type]),
+input[type="text"],
+input[type="password"],
+input[type="url"],
+input[type="tel"],
+input[type="search"],
+input[type="email"],
+input[type="date"],
+input[type="number"],
+select,
+textarea{
+  display:block;
+  width:100%;
+  padding: 10px 5px;
+  height:auto;
+  border:1px solid;
+  background-color:#fff;
+  border-color:#9ba8b1;
+  border-radius:2px;
+  outline: none;
+  line-height: 1.25em;
+}
+
+
+input:not([type]):hover,
+input[type="text"]:hover,
+input[type="password"]:hover,
+input[type="url"]:hover,
+input[type="tel"]:hover,
+input[type="search"]:hover,
+input[type="email"]:hover,
+input[type="date"]:hover,
+input[type="number"]:hover,
+select:hover,
+textarea:hover{
+  border-color:#7d868c;
+}
+
+
+input:not([type]):disabled,
+input[type="text"]:disabled,
+input[type="password"]:disabled,
+input[type="url"]:disabled,
+input[type="tel"]:disabled,
+input[type="search"]:disabled,
+input[type="email"]:disabled,
+input[type="date"]:disabled,
+input[type="number"]:disabled,
+select:disabled,
+textarea:disabled{
+    color:#9ba8b1;
+    background-color:#edf0f1;
+}
+
+/* eksperimentel søkeicon i søkefelt :sn */
+input[type="search"]{
+    background: #fff url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNSIgaGVpZ2h0PSIxNSIgdmlld0JveD0iMTkuNSAxMTkuNSA2MiA2MiIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAxOS41IDExOS41IDYyIDYyIj48cGF0aCBkPSJNNjUuNzk5IDE0Ni4wODNjMC0xMC44MjMtOC43NzctMTkuNjAxLTE5LjYxNS0xOS42MDEtMTAuODMgMC0xOS42MTQgOC43NzctMTkuNjE0IDE5LjYwMSAwIDEwLjgzOSA4Ljc4NCAxOS42MTYgMTkuNjE0IDE5LjYxNiAxMC44MzcgMCAxOS42MTUtOC43NzcgMTkuNjE1LTE5LjYxNnoiIGZpbGw9Im5vbmUiLz48cGF0aCBmaWxsPSIjOWJhOGIxIiBkPSJNODAuOTgyIDE3NS44MThsLTEzLjkyLTEzLjkyNGMzLjMzNi00LjM5MyA1LjMxNi05Ljg2NyA1LjMxNi0xNS44MTIgMC0xNC40NTctMTEuNzI1LTI2LjE3Ny0yNi4xOTUtMjYuMTc3LTE0LjQ1NyAwLTI2LjE4NCAxMS43Mi0yNi4xODQgMjYuMTc3IDAgMTQuNDcyIDExLjcyNyAyNi4xOTYgMjYuMTg0IDI2LjE5NiA1LjkyOSAwIDExLjQwOC0xLjk4MyAxNS43OTQtNS4zMDdsMTMuOTI0IDEzLjkyMiA1LjA4MS01LjA3NXptLTU0LjQxMi0yOS43MzVjMC0xMC44MjMgOC43ODQtMTkuNjAxIDE5LjYxNC0xOS42MDEgMTAuODM1IDAgMTkuNjE1IDguNzc3IDE5LjYxNSAxOS42MDEgMCAxMC44MzktOC43NzcgMTkuNjE2LTE5LjYxNSAxOS42MTYtMTAuODMgMC0xOS42MTQtOC43NzctMTkuNjE0LTE5LjYxNnoiLz48L3N2Zz4=)
+                10px center no-repeat;
+    text-indent: 20px;
+    -webkit-transition: border linear 0.1s, text-indent 0.1s, box-shadow 0.1s, background-position 0.1s;
+    transition: border linear 0.1s, text-indent 0.1s, box-shadow 0.1s, background-position 0.1s;
+    -webkit-appearance: none;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+input[type="search"]:focus {
+    background-position: -20px center;
+    text-indent: 0;
+}
+
+input:not([type]):focus,
+input[type="text"]:focus,
+input[type="password"]:focus,
+input[type="url"]:focus,
+input[type="tel"]:focus,
+input[type="search"]:focus,
+input[type="email"]:focus,
+input[type="date"]:focus,
+input[type="number"]:focus,
+textarea:focus,
+select:focus {
+    outline: 0;
+    border-color: #52A8EC;
+    box-shadow: inset 1px 1px 6px rgba(79, 102, 118, 0.25);
+}
+
+
+input[type=button],
+input[type=submit],
+input[type=reset],
+button,
+a.icon,
+a.button{
+  color:#0077ee;
+  border-color: #0077ee;
+  border-radius: 2px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  height: auto;
+  outline: none;
+  line-height: 1.25em;
+}
+
+input[type=button]:hover,
+input[type=submit]:hover,
+input[type=reset]:hover,
+button:hover,
+a.icon:hover,
+a.button:hover{
+    background: #f2faff;
+    text-decoration: none;
+}
+
+input[type=button]:active,
+input[type=submit]:active,
+input[type=reset]:active,
+button:active,
+a.icon:active,
+a.button:active{
+  background: #e5f5ff;
+}
+
+input.order,
+button.order,
+a.icon.order,
+a.button.order{
+    border:1px solid #e68007;
+    color:#fff;
+}
+
+input[type=button],
+input[type=submit],
+input[type=reset],
+button,
+a.icon,
+a.button{
+
+  background: #fdfeff;
+  background-image: -moz-linear-gradient(top, #fdfeff, #f4fbff);
+  background-image: -webkit-linear-gradient(top, #fdfeff, #f4fbff);
+  background-image: -o-linear-gradient(top, #fdfeff, #f4fbff);
+  background-image: linear-gradient(top, #fdfeff, #f4fbff);
+}
+
+

--- a/src/styles/skins/finn/template/template.css
+++ b/src/styles/skins/finn/template/template.css
@@ -1,0 +1,3 @@
+body, html {
+    background-color:#e9eff5;
+}


### PR DESCRIPTION
The current Spaden package comes with a lot of custom coloring and behavior which has to be overridden in order to use it for a different brand. This is outlined in issue #8.
This PR moves most of the coloring and behavior which is specific to Finn.no into a separate structure outlining how others might do similar things.
All the skin styles for finn is now in the finn.css. This is not ideal, but I assume this will break fewer things. Ideally the finn.css would reside in the skins/finn/ folder instead.