### PR TITLE
Add utility class to make grid columns snap to fullwidth when printing

### DIFF
--- a/src/styles/core/print/print.css
+++ b/src/styles/core/print/print.css
@@ -50,8 +50,9 @@
     .line:after, .lastUnit:after {
         display: table;
         clear: both;
-        width: 100%; 
+        width: 100%;
     }
+    .print-fullwidth { width: 100%; }
     /* Spacing */
     h1, h2, h3, h4, h5, h6, ul, ol, dl, p, blockquote, .media { margin: 5px 10px; }
     dt, dd { margin: 0 10px; }


### PR DESCRIPTION
We see a need for outputting some elements fullscreen when printing on m.finn.no (our case was due to a js chart library causing the chart to fill the entire page on print even when the container element was part of the grid). 

To get around this problem in a simple way, we just want to be able to snap come grid columns to fullwidth when printing.

I have not created a separate issue for this PR since it has already been discussed with team members on spaden.