### PR TITLE
Altering .thumb class, replacing with for max-with and adding max-hei…

### DIFF
--- a/src/styles/components/gallery/gallery.css
+++ b/src/styles/components/gallery/gallery.css
@@ -251,7 +251,8 @@ when the page is scrolled and the browser chrome disappears, will recalculate `v
 }
 
 .thumb {
-    width: 84px;
+    max-width: 84px;
+    max-height: 84px;
     margin: 0 5px 0 0;
     border: solid 2px transparent;
 }


### PR DESCRIPTION
## Fix for broken gallery  ##
A Solution for the problem with small portrait photos breaking the layout of image carousels on mobile devices.  The issue is described [on Team Red´s Trello board](https://trello.com/c/YTnKKPGW)
But to summarize the issue is that small portrait photos is not cropped correct from the server, and resulting in as depicted in the attached screenshot. 

I have tested by viewing a random selection of ads from all our markets and sub-markets with the fix implemented, and I have not discovered any side effects or broken galleries. 

### Current situation ###
Server  and front is unable to crop small portrait photos correctly, causing the front to break the on mobile devices:
![current](https://cloud.githubusercontent.com/assets/15084058/12472933/a9f1073a-c00d-11e5-822c-a3ee52ba2f15.png)

### The fix ###
Setting *max-height* and *max-with* ensures the carousel remains unbroken and the aspect ration of the thumbs remain the same, 
![max_size_example](https://cloud.githubusercontent.com/assets/15084058/12472934/b73574a8-c00d-11e5-965b-01b1ad352495.png)
 