### PR TITLE
Add link in README to hosted version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 There is a figure of speech which is to [call a spade a spade](https://en.wikipedia.org/wiki/Call_a_spade_a_spade). This is (not) the reason this project is called Spaden.
 
-A hosted version of this project can be found [here](https://styleguide.finn.no/).
+A hosted version of this project can be found at [styleguide.finn.no](https://styleguide.finn.no/).
 
 [![travis status](https://api.travis-ci.org/finn-no/spaden.png)](https://travis-ci.org/finn-no/spaden)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 There is a figure of speech which is to [call a spade a spade](https://en.wikipedia.org/wiki/Call_a_spade_a_spade). This is (not) the reason this project is called Spaden.
 
+A hosted version of this project can be found [here](https://styleguide.finn.no/).
+
 [![travis status](https://api.travis-ci.org/finn-no/spaden.png)](https://travis-ci.org/finn-no/spaden)
 
 [![NPM](https://nodei.co/npm/spaden.png?stars&downloads)](https://nodei.co/npm/spaden/)


### PR DESCRIPTION
I was talking about Spaden to people in Schibsted and they were wondering if it was hosted somewhere. I linked them to the styleguide but maybe this can be linked from the README for people in the future with the same question =)