### PR TITLE
ADOUT-1460 css fix for brolen dl on newbuildings ads

### DIFF
--- a/src/styles/core/lists/lists.css
+++ b/src/styles/core/lists/lists.css
@@ -51,6 +51,7 @@ dl.colspan4 { width: 650px; }
     -webkit-column-break-inside: avoid;
     page-break-inside: avoid;
     break-inside: avoid;
+    -webkit-column-break-after: always;
 }
 .multicol dd:after {
     display: block;


### PR DESCRIPTION
This will fix the broken lists with long values in dd-tags on webkit-browsers.
